### PR TITLE
実装の強制なしに互換性がある場合の例のため、implementsを削除

### DIFF
--- a/code/types-basic/structural-subtypings/class-compat.ts
+++ b/code/types-basic/structural-subtypings/class-compat.ts
@@ -8,7 +8,7 @@ class PointImpl1 implements Point {
 	}
 }
 // Point の実装が強制されないけど互換性はある！
-class PointImpl2 implements Point {
+class PointImpl2 {
 	constructor(public x: number, public y: number) {
 	}
 }


### PR DESCRIPTION
http://typescript.ninja/typescript-in-definitelyland/types-basic.html#h3-4
こちらのリスト3.13のコードについて

構造的部分型の説明として、
* `PointImpl1`は`implements`あり
* `PointImpl2`は`implements`なし

のほうが例として適切ではないかと思ったのですが、いかがでしょうか？